### PR TITLE
[Bug] Make sure to destroy `user_input_thread_running_mutex`

### DIFF
--- a/sources/user_input.c
+++ b/sources/user_input.c
@@ -66,6 +66,9 @@ void user_input_thread_join() {
 
 void user_input_destroy() {
   pthread_mutex_destroy(&user_input_mutex);
+  pthread_mutex_destroy(
+    &user_input_thread_running_mutex
+  );
 }
 
 void* __user_input_get() { 


### PR DESCRIPTION
`user_input_thread_running_mutex` wasn't being destroyed when it should have.